### PR TITLE
Fix prometheus start for version 2.6.0 onwards

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -773,6 +773,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMapName
 						Name:           "prometheus",
 						Image:          prometheusImage,
 						Ports:          ports,
+						Command:        []string{"/bin/prometheus"},
 						Args:           promArgs,
 						VolumeMounts:   promVolumeMounts,
 						LivenessProbe:  livenessProbe,


### PR DESCRIPTION
Due to the changes on Prometheus Dockerfile (https://github.com/prometheus/prometheus/pull/4796), the arguments and CMD are merged into ENTRYPOINT. This breaks the launch from prometheus-operator causing duplicate arguments.

I added more info on Issue https://github.com/coreos/prometheus-operator/issues/2204